### PR TITLE
Use Adobe flavor of TIFF DEFLATE

### DIFF
--- a/src/core/resources/TiffCompressionMethods.tsv
+++ b/src/core/resources/TiffCompressionMethods.tsv
@@ -1,6 +1,7 @@
 #NAME	ID	DESCRIPTION	NOT FILTERED	B/W ONLY
 LZW	5	Lempel-Ziv & Welch	1	0
-DEFLATE	32946	Deflate compression	1	0
+ADOBEDEFLATE	8	Deflate compression (as recognized by Adobe)	1	0
+DEFLATE	32946	Deflate compression (legacy libtiff)	0	0
 DCS	32947	Kodak DCS encoding	0	0
 JBIG	34661	ISO JBIG	0	0
 SGILOG	34676	SGI Log	0	0


### PR DESCRIPTION
At present, the DEFLATE method used for TIFF is the nonstandard libtiff version. This changes it to using the standardized "AdobeDeflate" compression method. The nonstandard method is still available when the "Hide rare or unsupported methods" box is unchecked.