### PR TITLE
Fix executable name in Info.plist.in

### DIFF
--- a/src/packaging/osx/Info.plist.in
+++ b/src/packaging/osx/Info.plist.in
@@ -7,7 +7,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleExecutable</key>
-	<string>ScanTailorUniversal</string>
+	<string>scantailor-universal</string>
 	<key>CFBundleName</key>
 	<string>ScanTailorUniversal</string>
 	<key>CFBundlePackageType</key>


### PR DESCRIPTION
This corrects the executable name so that the built Mac .app works correctly.